### PR TITLE
Add missing unloadAsync function

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,19 @@ class Sound {
     }
   };
 
+  async unloadAsync() {
+    if (this._loaded) {
+      this._loaded = false;
+      const key = this._key;
+      this._key = -1;
+      const status = await NativeModules.ExponentAV.unloadForSound(key);
+      this._callOnPlaybackStatusUpdateForNewStatus(status);
+      return status;
+    } else {
+      return this.getStatusAsync(); // Automatically calls onPlaybackStatusUpdate.
+    }
+  }
+
   //API methods
   async setStatusAsync(status) {
     //      console.error('Requested position after replay has to be 0.');


### PR DESCRIPTION
Thanks for the repo, it helps greatly for gapless looping on Android!

This PR adds the `unloadAsync` function. Though `unloadAsync` is referenced in the README, it doesn't actually exist in the code. I've added it, based on the code from Expo linked below.

https://github.com/expo/expo/blob/8d441c7e9b081cfdd6a45edc165251d7273225a0/packages/expo-av/src/Audio/Sound.ts#L196-L208